### PR TITLE
Set DeletionPolicyForeground on deployment delete

### DIFF
--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -298,7 +298,10 @@ func resourceKubernetesDeploymentDelete(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	err = conn.ExtensionsV1beta1().Deployments(namespace).Delete(name, &metav1.DeleteOptions{})
+	policy := metav1.DeletePropagationForeground
+	err = conn.ExtensionsV1beta1().Deployments(namespace).Delete(name, &metav1.DeleteOptions{
+		PropagationPolicy: &policy,
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
After I rebased the custom branch on upstream master, and push forcing to this repo, PR #3 was a bit of a mess ( no fault of @jeffmhastings ). This PR is a replacement, with @jeffmhastings change cherry-picked on top.

Original description:
> I noticed that orphaned replica sets were being left behind after destroying a deployment resource. According to the documentation here it looks like that is because of the default orphan deletion policy on kubernetes < 1.9.

> This updates to the deployment Delete method to set the foreground deletion option on delete.

Thanks @jeffmhastings