### PR TITLE
Fix StatefulSet update strategy

### DIFF
--- a/kubernetes/resource_kubernetes_stateful_set_test.go
+++ b/kubernetes/resource_kubernetes_stateful_set_test.go
@@ -81,6 +81,57 @@ func TestAccKubernetesStatefulSet_pvcTemplate(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesStatefulSet_updateStrategy(t *testing.T) {
+	var sset v1.StatefulSet
+
+	statefulSetName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubernetesStatefulSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesStatefulSetConfig_updateStrategy(statefulSetName, "RollingUpdate"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesStatefulSetExists("kubernetes_stateful_set.test", &sset),
+					resource.TestCheckResourceAttr("kubernetes_stateful_set.test", "metadata.0.name", statefulSetName),
+					resource.TestCheckResourceAttr("kubernetes_stateful_set.test", "metadata.0.labels.%", "0"),
+					resource.TestCheckResourceAttrSet("kubernetes_stateful_set.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_stateful_set.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_stateful_set.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_stateful_set.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_stateful_set.test", "spec.0.service_name", statefulSetName),
+					resource.TestCheckResourceAttr("kubernetes_stateful_set.test", "spec.0.update_strategy.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_stateful_set.test", "spec.0.update_strategy.0.type", "RollingUpdate"),
+				),
+			},
+			{
+				Config: testAccKubernetesStatefulSetConfig_updateStrategy(statefulSetName, "OnDelete"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesStatefulSetExists("kubernetes_stateful_set.test", &sset),
+					resource.TestCheckResourceAttr("kubernetes_stateful_set.test", "metadata.0.name", statefulSetName),
+					resource.TestCheckResourceAttr("kubernetes_stateful_set.test", "spec.0.service_name", statefulSetName),
+					resource.TestCheckResourceAttr("kubernetes_stateful_set.test", "spec.0.update_strategy.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_stateful_set.test", "spec.0.update_strategy.0.type", "OnDelete"),
+				),
+			},
+			{
+				Config: testAccKubernetesStatefulSetConfig_updateStrategyRollingUpdate(statefulSetName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesStatefulSetExists("kubernetes_stateful_set.test", &sset),
+					resource.TestCheckResourceAttr("kubernetes_stateful_set.test", "metadata.0.name", statefulSetName),
+					resource.TestCheckResourceAttr("kubernetes_stateful_set.test", "spec.0.service_name", statefulSetName),
+					resource.TestCheckResourceAttr("kubernetes_stateful_set.test", "spec.0.update_strategy.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_stateful_set.test", "spec.0.update_strategy.0.type", "RollingUpdate"),
+					resource.TestCheckResourceAttr("kubernetes_stateful_set.test", "spec.0.update_strategy.0.rolling_update.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_stateful_set.test", "spec.0.update_strategy.0.rolling_update.0.partition", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckKubernetesStatefulSetExists(n string, obj *v1.StatefulSet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -197,4 +248,91 @@ resource "kubernetes_stateful_set" "test" {
   }
 }
 `, name, name, image)
+}
+
+func testAccKubernetesStatefulSetConfig_updateStrategy(name, strategy string) string {
+	return fmt.Sprintf(`
+resource kubernetes_stateful_set "test" {
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    selector {
+      app = "pinger"
+    }
+
+    service_name = "%s"
+
+    update_strategy {
+      type = "%s"
+    }
+
+    replicas = 2
+
+    template {
+      metadata {
+        labels {
+          app = "pinger"
+        }
+      }
+
+      spec {
+        termination_grace_period_seconds = 5
+
+        container {
+          name = "pinger-a"
+          image = "debian:buster"
+          command = ["ping", "github.com"]
+        }
+      }
+    }
+  }
+}
+`, name, name, strategy)
+}
+
+func testAccKubernetesStatefulSetConfig_updateStrategyRollingUpdate(name string) string {
+	return fmt.Sprintf(`
+resource kubernetes_stateful_set "test" {
+  metadata {
+    name = "%s"
+  }
+
+  spec {
+    selector {
+      app = "pinger"
+    }
+
+    service_name = "%s"
+
+    update_strategy {
+      type = "RollingUpdate"
+	  rolling_update {
+        partition = 1
+      }
+    }
+
+    replicas = 2
+
+    template {
+      metadata {
+        labels {
+          app = "pinger"
+        }
+      }
+
+      spec {
+        termination_grace_period_seconds = 5
+
+        container {
+          name = "pinger-a"
+          image = "debian:buster"
+          command = ["ping", "github.com"]
+        }
+      }
+    }
+  }
+}
+`, name, name)
 }

--- a/kubernetes/structures_stateful_set.go
+++ b/kubernetes/structures_stateful_set.go
@@ -75,9 +75,11 @@ func expandStatefulSetSpec(statefulSet []interface{}) (appsv1.StatefulSetSpec, e
 		return obj, nil
 	}
 	in := statefulSet[0].(map[string]interface{})
-	if v, ok := in["strategy"]; ok {
+
+	if v, ok := in["update_strategy"]; ok {
 		obj.UpdateStrategy = expandStatefulSetUpdateStrategy(v.([]interface{}))
 	}
+
 	obj.Replicas = ptrToInt32(int32(in["replicas"].(int)))
 	obj.Selector = &metav1.LabelSelector{
 		MatchLabels: expandStringMap(in["selector"].(map[string]interface{})),
@@ -127,8 +129,10 @@ func expandStatefulSetUpdateStrategy(p []interface{}) appsv1.StatefulSetUpdateSt
 	if v, ok := in["type"]; ok {
 		obj.Type = appsv1.StatefulSetUpdateStrategyType(v.(string))
 	}
-	if v, ok := in["rolling_update"]; ok {
-		obj.RollingUpdate = expandRollingUpdateStatefulSetStrategy(v.([]interface{}))
+	if obj.Type == appsv1.RollingUpdateStatefulSetStrategyType {
+		if v, ok := in["rolling_update"]; ok {
+			obj.RollingUpdate = expandRollingUpdateStatefulSetStrategy(v.([]interface{}))
+		}
 	}
 	return obj
 }
@@ -141,7 +145,7 @@ func expandRollingUpdateStatefulSetStrategy(p []interface{}) *appsv1.RollingUpda
 	in := p[0].(map[string]interface{})
 
 	if v, ok := in["partition"]; ok {
-		obj.Partition = ptrToInt32(v.(int32))
+		obj.Partition = ptrToInt32(int32(v.(int)))
 	}
 
 	return &obj


### PR DESCRIPTION
Prior to this PR, StatefulSets did not update the UpdateStrategy type (`OnDelete`, `RollingUpdate`).
This is now fixed, and acceptance test has been added:

```
=== RUN   TestAccKubernetesStatefulSet_basic
--- PASS: TestAccKubernetesStatefulSet_basic (104.53s)
=== RUN   TestAccKubernetesStatefulSet_pvcTemplate
--- PASS: TestAccKubernetesStatefulSet_pvcTemplate (47.69s)
=== RUN   TestAccKubernetesStatefulSet_updateStrategy
--- PASS: TestAccKubernetesStatefulSet_updateStrategy (39.01s)
```

Fixes #13 