### PR TITLE
Cronjob / Job backoff limit attribute

### DIFF
--- a/kubernetes/resource_kubernetes_cron_job_test.go
+++ b/kubernetes/resource_kubernetes_cron_job_test.go
@@ -32,6 +32,7 @@ func TestAccKubernetesCronJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_cron_job.test", "spec.0.schedule"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.parallelism", "1"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.backoff_limit", "2"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.template.0.spec.0.container.0.name", "hello"),
 				),
 			},
@@ -46,6 +47,7 @@ func TestAccKubernetesCronJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_cron_job.test", "metadata.0.uid"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.parallelism", "2"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.backoff_limit", "0"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.template.0.spec.0.container.0.name", "hello"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.template.0.metadata.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.template.0.metadata.0.labels.%", "2"),
@@ -75,6 +77,7 @@ func TestAccKubernetesCronJob_extra(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.successful_jobs_history_limit", "10"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.failed_jobs_history_limit", "10"),
 					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.starting_deadline_seconds", "60"),
+					resource.TestCheckResourceAttr("kubernetes_cron_job.test", "spec.0.job_template.0.spec.0.backoff_limit", "2"),
 				),
 			},
 		},
@@ -139,6 +142,7 @@ resource "kubernetes_cron_job" "test" {
 		schedule = "1 0 * * *"
 		job_template {
 			spec {
+				backoff_limit = 2
 				template {
 					spec {
 						container {
@@ -200,6 +204,7 @@ resource "kubernetes_cron_job" "test" {
     	starting_deadline_seconds     = 60
 		job_template {
 			spec {
+				backoff_limit = 2
 				template {
 					spec {
 						container {

--- a/kubernetes/resource_kubernetes_job_test.go
+++ b/kubernetes/resource_kubernetes_job_test.go
@@ -109,6 +109,7 @@ resource "kubernetes_job" "test" {
 	}
 	spec {
 		parallelism = 2
+		backoff_limit = 4
 		template {
 			metadata {
 				labels {
@@ -135,6 +136,7 @@ resource "kubernetes_job" "test" {
 	}
 	spec {
 		parallelism = 2
+		backoff_limit = 6
 		template {
 			spec {
 				container {

--- a/kubernetes/schema_job_spec.go
+++ b/kubernetes/schema_job_spec.go
@@ -12,6 +12,12 @@ func jobSpecFields() map[string]*schema.Schema {
 			ValidateFunc: validatePositiveInteger,
 			Description:  "Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.",
 		},
+		"backoff_limit": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ValidateFunc: validatePositiveInteger,
+			Description:  "Specifies the number of retries before marking this job failed. Defaults to 6",
+		},
 		"completions": {
 			Type:         schema.TypeInt,
 			Optional:     true,

--- a/kubernetes/structure_job.go
+++ b/kubernetes/structure_job.go
@@ -12,6 +12,10 @@ func flattenJobSpec(in batchv1.JobSpec, d *schema.ResourceData) ([]interface{}, 
 		att["active_deadline_seconds"] = *in.ActiveDeadlineSeconds
 	}
 
+	if in.BackoffLimit != nil {
+		att["backoff_limit"] = *in.BackoffLimit
+	}
+
 	if in.Completions != nil {
 		att["completions"] = *in.Completions
 	}
@@ -59,6 +63,10 @@ func expandJobSpec(j []interface{}) (batchv1.JobSpec, error) {
 
 	if v, ok := in["active_deadline_seconds"].(int); ok && v > 0 {
 		obj.ActiveDeadlineSeconds = ptrToInt64(int64(v))
+	}
+
+	if v, ok := in["backoff_limit"].(int); ok && v != 6 {
+		obj.BackoffLimit = ptrToInt32(int32(v))
 	}
 
 	if v, ok := in["completions"].(int); ok && v > 0 {


### PR DESCRIPTION
This PR adds the `backoff_limit` attribute to CronJob / Job `job_template`.

"Specifies the number of retries before marking this job failed. Defaults to 6"
https://v1-8.docs.kubernetes.io/docs/api-reference/v1.8/#jobspec-v1-batch