### PR TITLE
Static compilation for binaries

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -47,7 +47,7 @@ test-compile:
 targets: $(TARGETS)
 
 $(TARGETS):
-	GOOS=$@ GOARCH=amd64 go build -o "dist/$@/terraform-provider-kubernetes_${TRAVIS_TAG}_x4"
+	GOOS=$@ GOARCH=amd64 CGO_ENABLED=0 go build -o "dist/$@/terraform-provider-kubernetes_${TRAVIS_TAG}_x4" -a -ldflags '-extldflags "-static"'
 	zip -j dist/terraform-provider-kubernetes_${TRAVIS_TAG}_$@_amd64.zip dist/$@/terraform-provider-kubernetes_${TRAVIS_TAG}_x4
 
 .PHONY: build test testacc vet fmt fmtcheck errcheck vendor-status test-compile targets $(TARGETS)


### PR DESCRIPTION
We use the official terraform docker image instead of having terraform installed on machines. This provider was giving us issues due to the fact it wasn't statically compiled (the terraform docker image is based off an alpine container)

This change compiles the binaries statically for all platforms.