### PR TITLE
Don't ForceNew for label changes.

### DIFF
--- a/kubernetes/schema_label_selector.go
+++ b/kubernetes/schema_label_selector.go
@@ -10,26 +10,22 @@ func labelSelectorFields() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Description: "A list of label selector requirements. The requirements are ANDed.",
 			Optional:    true,
-			ForceNew:    true,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"key": {
 						Type:        schema.TypeString,
 						Description: "The label key that the selector applies to.",
 						Optional:    true,
-						ForceNew:    true,
 					},
 					"operator": {
 						Type:        schema.TypeString,
 						Description: "A key's relationship to a set of values. Valid operators ard `In`, `NotIn`, `Exists` and `DoesNotExist`.",
 						Optional:    true,
-						ForceNew:    true,
 					},
 					"values": {
 						Type:        schema.TypeSet,
 						Description: "An array of string values. If the operator is `In` or `NotIn`, the values array must be non-empty. If the operator is `Exists` or `DoesNotExist`, the values array must be empty. This array is replaced during a strategic merge patch.",
 						Optional:    true,
-						ForceNew:    true,
 						Elem:        &schema.Schema{Type: schema.TypeString},
 						Set:         schema.HashString,
 					},
@@ -40,7 +36,6 @@ func labelSelectorFields() map[string]*schema.Schema {
 			Type:        schema.TypeMap,
 			Description: "A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
 			Optional:    true,
-			ForceNew:    true,
 		},
 	}
 }


### PR DESCRIPTION
I noticed this while writing #57 and adding affinity to a deployment would have destroyed it. I don't think there should be any reason to `ForceNew` when changing label selectors (or anything in the kubernetes API really, since Kubernetes manages merges itself using its semantics).