### PR TITLE
Add toleration support to pod spec

### DIFF
--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -174,6 +174,43 @@ func podSpecFields(isUpdatable bool) map[string]*schema.Schema {
 			ValidateFunc: validateTerminationGracePeriodSeconds,
 			Description:  "Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.",
 		},
+		"toleration": {
+			Type:        schema.TypeList,
+			Description: "Tolerations is an optional list of node tolerations controlling where pod can be placed",
+			Optional:    true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"key": {
+						Type:        schema.TypeString,
+						Description: "Key for toleration effect",
+						Optional:    true,
+					},
+					"value": {
+						Type:        schema.TypeString,
+						Description: "Value for key",
+						Optional:    true,
+					},
+					"operator": {
+						Type:         schema.TypeString,
+						ValidateFunc: validateAttributeValueIsIn([]string{"Exists", "Equal"}),
+						Description:  "Type of check for toleration type",
+						Optional:     true,
+					},
+					"effect": {
+						Type:         schema.TypeString,
+						ValidateFunc: validateAttributeValueIsIn([]string{"NoSchedule", "PreferNoSchedule", "NoExecute"}),
+						Description:  "Toleration effect",
+						Optional:     true,
+					},
+					"toleration_seconds": {
+						Type:         schema.TypeInt,
+						ValidateFunc: validatePositiveInteger,
+						Description:  "Time allowance before pod is evicted when toleration is in effect",
+						Optional:     true,
+					},
+				},
+			},
+		},
 
 		"volume": {
 			Type:        schema.TypeList,

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -1,8 +1,9 @@
 package kubernetes
 
 import (
-	"fmt"
+	"log"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"k8s.io/api/core/v1"
@@ -147,40 +148,25 @@ func flattenSeLinuxOptions(in *v1.SELinuxOptions) []interface{} {
 }
 
 func flattenTolerations(tolerations []v1.Toleration) ([]map[string]interface{}, error) {
-	ts := make([]map[string]interface{}, len(tolerations))
-	for i, t := range tolerations {
-		var operator string
-		switch t.Operator {
-		case v1.TolerationOpEqual:
-			operator = "Equal"
-		case v1.TolerationOpExists:
-			operator = "Exists"
-		default:
-			return []map[string]interface{}{}, fmt.Errorf("Unknown toleration operator %v", t.Operator)
+	//ts := make([]map[string]interface{}, len(tolerations))
+	ts := []map[string]interface{}{}
+	for _, t := range tolerations {
+		// The API Server may automatically add several Tolerations to pods, strip these to avoid TF diff.
+		if strings.Contains(t.Key, "node.kubernetes.io/") {
+			log.Printf("[INFO] ignoring toleration with key: %s", t.Key)
+			continue
 		}
-
-		var effect string
-		switch t.Effect {
-		case v1.TaintEffectNoExecute:
-			effect = "NoExecute"
-		case v1.TaintEffectNoSchedule:
-			effect = "NoSchedule"
-		case v1.TaintEffectPreferNoSchedule:
-			effect = "PreferNoSchedule"
-		default:
-			return []map[string]interface{}{}, fmt.Errorf("Unknown taint effect %v", t.Effect)
-		}
-
-		ts[i] = map[string]interface{}{
+		tol := map[string]interface{}{
 			"key":      t.Key,
-			"operator": operator,
-			"effect":   effect,
+			"operator": string(t.Operator),
+			"effect":   string(t.Effect),
 			"value":    t.Value,
 		}
 
 		if t.TolerationSeconds != nil {
-			ts[i]["toleration_seconds"] = *(t.TolerationSeconds)
+			tol["toleration_seconds"] = *(t.TolerationSeconds)
 		}
+		ts = append(ts, tol)
 	}
 	return ts, nil
 }
@@ -487,18 +473,19 @@ func expandPodSpec(p []interface{}) (v1.PodSpec, error) {
 		obj.TerminationGracePeriodSeconds = ptrToInt64(int64(v))
 	}
 
-	if v, ok := in["toleration"].([]map[string]interface{}); ok && len(v) > 0 {
+	if v, ok := in["toleration"].([]interface{}); ok && len(v) > 0 {
 		tolerations := make([]v1.Toleration, len(v))
-		for i, t := range v {
+		for i, tmap := range v {
+			t := tmap.(map[string]interface{})
 			tol := v1.Toleration{
 				Key:      t["key"].(string),
-				Operator: tolerationOperator(t["operator"].(string)),
-				Effect:   taintEffect(t["effect"].(string)),
+				Operator: v1.TolerationOperator(t["operator"].(string)),
+				Effect:   v1.TaintEffect(t["effect"].(string)),
 				Value:    t["value"].(string),
 			}
-			sec := t["toleration_seconds"].(int64)
+			sec := t["toleration_seconds"].(int)
 			if sec > 0 {
-				tol.TolerationSeconds = &sec
+				tol.TolerationSeconds = ptrToInt64(int64(sec))
 			}
 			tolerations[i] = tol
 		}
@@ -513,30 +500,6 @@ func expandPodSpec(p []interface{}) (v1.PodSpec, error) {
 		obj.Volumes = cs
 	}
 	return obj, nil
-}
-
-func tolerationOperator(operator string) (val v1.TolerationOperator) {
-	switch operator {
-	case "Exists":
-		val = v1.TolerationOpExists
-	case "Equal":
-		val = v1.TolerationOpEqual
-	}
-	return
-}
-
-func taintEffect(effect string) (val v1.TaintEffect) {
-	switch effect {
-	case "NoSchedule":
-		val = v1.TaintEffectNoSchedule
-	case "PreferNoSchedule":
-		val = v1.TaintEffectPreferNoSchedule
-	// case "NoScheduleNoAdmit":
-	// 	val = v1.TaintEffectNoScheduleNoAdmit
-	case "NoExecute":
-		val = v1.TaintEffectNoExecute
-	}
-	return
 }
 
 func expandPodSecurityContext(l []interface{}) *v1.PodSecurityContext {


### PR DESCRIPTION
Replaces #22 

Example 

```tf
resource "kubernetes_pod" "test" {
  metadata {
    name = "poddy"
  }

  spec {
    container {
      image = "nginx"
      name  = "containername"
    }
    toleration {
      key   = "taintkey"
      value = "taintvalue"
    }
    toleration {
      key                = "taintkey2"
      operator           = "Exists"
      toleration_seconds = 30
      effect             = "NoExecute"
    }
  }
}
```