### PR TITLE
Fix “expected pointer, but got nil” error when Deployment strategy = Recreate

### DIFF
--- a/kubernetes/api_versions.go
+++ b/kubernetes/api_versions.go
@@ -99,12 +99,12 @@ func (kp *kubernetesProvider) serverSupportsResourceAPIVersion(rname string, gro
 func Convert(item, out interface{}) error {
 	bytes, err := json.Marshal(item)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to convert API object - Marshal failed: %s", err)
 	}
 
 	err = json.Unmarshal(bytes, out)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to convert API object - Unmarshal failed: %s", err)
 	}
 
 	return nil

--- a/kubernetes/resource_kubernetes_deployment.go
+++ b/kubernetes/resource_kubernetes_deployment.go
@@ -98,7 +98,7 @@ func resourceKubernetesDeployment() *schema.Resource {
 							Type:        schema.TypeList,
 							Optional:    true,
 							Computed:    true,
-							Description: "Update strategy. One of RollingUpdate, Destroy. Defaults to RollingDate",
+							Description: "Update strategy. One of RollingUpdate, Recreate. Defaults to RollingDate",
 							MaxItems:    1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -118,15 +118,15 @@ func resourceKubernetesDeployment() *schema.Resource {
 											Schema: map[string]*schema.Schema{
 												"max_surge": {
 													Type:        schema.TypeString,
-													Description: "max surge",
+													Description: "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods.",
 													Optional:    true,
-													Default:     1,
+													Default:     "25%",
 												},
 												"max_unavailable": {
 													Type:        schema.TypeString,
-													Description: "max unavailable",
+													Description: "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old RC can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.",
 													Optional:    true,
-													Default:     1,
+													Default:     "25%",
 												},
 											},
 										},


### PR DESCRIPTION
When Deployment strategy = `Recreate` the RollingUpdate object should not be set.
Full error:
`Failed to create deployment: Deployment in version "v1" cannot be handled as a Deployment: expected pointer, but got nil`

Fixes #61 