### PR TITLE
Add empty image diff suppression.

### DIFF
--- a/kubernetes/diff_supress_funcs.go
+++ b/kubernetes/diff_supress_funcs.go
@@ -16,3 +16,10 @@ func suppressEquivalentResourceQuantity(k, old, new string, d *schema.ResourceDa
 	}
 	return oldQ.Cmp(newQ) == 0
 }
+
+func suppressNewImage(k, old, new string, d *schema.ResourceData) bool {
+	if new != "" {
+		return false
+	}
+	return true
+}

--- a/kubernetes/schema_container.go
+++ b/kubernetes/schema_container.go
@@ -374,9 +374,10 @@ func containerFields(isUpdatable bool) map[string]*schema.Schema {
 			},
 		},
 		"image": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "Docker image name. More info: http://kubernetes.io/docs/user-guide/images",
+			Type:             schema.TypeString,
+			Optional:         true,
+			DiffSuppressFunc: suppressNewImage,
+			Description:      "Docker image name. More info: http://kubernetes.io/docs/user-guide/images",
 		},
 		"image_pull_policy": {
 			Type:        schema.TypeString,

--- a/kubernetes/schema_label_selector.go
+++ b/kubernetes/schema_label_selector.go
@@ -10,26 +10,22 @@ func labelSelectorFields() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Description: "A list of label selector requirements. The requirements are ANDed.",
 			Optional:    true,
-			ForceNew:    true,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"key": {
 						Type:        schema.TypeString,
 						Description: "The label key that the selector applies to.",
 						Optional:    true,
-						ForceNew:    true,
 					},
 					"operator": {
 						Type:        schema.TypeString,
 						Description: "A key's relationship to a set of values. Valid operators ard `In`, `NotIn`, `Exists` and `DoesNotExist`.",
 						Optional:    true,
-						ForceNew:    true,
 					},
 					"values": {
 						Type:        schema.TypeSet,
 						Description: "An array of string values. If the operator is `In` or `NotIn`, the values array must be non-empty. If the operator is `Exists` or `DoesNotExist`, the values array must be empty. This array is replaced during a strategic merge patch.",
 						Optional:    true,
-						ForceNew:    true,
 						Elem:        &schema.Schema{Type: schema.TypeString},
 						Set:         schema.HashString,
 					},
@@ -40,7 +36,6 @@ func labelSelectorFields() map[string]*schema.Schema {
 			Type:        schema.TypeMap,
 			Description: "A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
 			Optional:    true,
-			ForceNew:    true,
 		},
 	}
 }


### PR DESCRIPTION
The state always shows a difference when our CI/CD systems patch the container image. We would like this suppression as we wanna update the deployment configuration like secrets and configmaps without changing the image. With this pull request whenever we give an empty string it suppresses the image diff. We have multiple deployments in one state so updating 20+ deployment images manually in the tf files doesn't make sense.