### PR TITLE
fix affinity.pod_(anti)_affinity namespaces missing in flattener

### DIFF
--- a/kubernetes/schema_label_selector.go
+++ b/kubernetes/schema_label_selector.go
@@ -10,26 +10,22 @@ func labelSelectorFields() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Description: "A list of label selector requirements. The requirements are ANDed.",
 			Optional:    true,
-			ForceNew:    true,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"key": {
 						Type:        schema.TypeString,
 						Description: "The label key that the selector applies to.",
 						Optional:    true,
-						ForceNew:    true,
 					},
 					"operator": {
 						Type:        schema.TypeString,
 						Description: "A key's relationship to a set of values. Valid operators ard `In`, `NotIn`, `Exists` and `DoesNotExist`.",
 						Optional:    true,
-						ForceNew:    true,
 					},
 					"values": {
 						Type:        schema.TypeSet,
 						Description: "An array of string values. If the operator is `In` or `NotIn`, the values array must be non-empty. If the operator is `Exists` or `DoesNotExist`, the values array must be empty. This array is replaced during a strategic merge patch.",
 						Optional:    true,
-						ForceNew:    true,
 						Elem:        &schema.Schema{Type: schema.TypeString},
 						Set:         schema.HashString,
 					},


### PR DESCRIPTION
without that fix each `terraform apply` reports a change in `namespaces` needs to be done. No matter if all namespaces are present in corresponding deployment.