### PR TITLE
Fixing panic when loading pods with env_from config_map_ref

### DIFF
--- a/kubernetes/structures_container.go
+++ b/kubernetes/structures_container.go
@@ -242,7 +242,9 @@ func flattenConfigMapEnvSource(in *v1.ConfigMapEnvSource) []interface{} {
 		att["name"] = in.Name
 	}
 
-	att["optional"] = *in.Optional
+	if in.Optional != nil {
+		att["optional"] = *in.Optional
+	}
 
 	return []interface{}{att}
 }
@@ -254,7 +256,9 @@ func flattenSecretEnvSource(in *v1.SecretEnvSource) []interface{} {
 		att["name"] = in.Name
 	}
 
-	att["optional"] = *in.Optional
+	if in.Optional != nil {
+		att["optional"] = *in.Optional
+	}
 
 	return []interface{}{att}
 }


### PR DESCRIPTION
Fixes #76 by wrapping the setting of `att["optional"]` in a check