### PR TITLE
Allows specified external keys to be handled correctly

### DIFF
--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -14,6 +14,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var externalKeys = []string{
+	"kubernetes.io/egress-bandwidth",
+	"kubernetes.io/ingress.class",
+	"app.kubernetes.io",
+	"service.beta.kubernetes.io",
+	"nginx.ingress.kubernetes.io",
+}
+
 func idParts(id string) (string, string, error) {
 	parts := strings.Split(id, "/")
 	if len(parts) != 2 {
@@ -163,6 +171,12 @@ func isKeyInMap(key string, d map[string]interface{}) bool {
 }
 
 func isInternalKey(annotationKey string) bool {
+	for _, key := range externalKeys {
+		if strings.Contains(annotationKey, key) {
+			return false
+		}
+	}
+
 	u, err := url.Parse("//" + annotationKey)
 	if err == nil && strings.Contains(u.Hostname(), "kubernetes.io") {
 		log.Printf("[DEBUG] %s is internal key", annotationKey)

--- a/kubernetes/structures_test.go
+++ b/kubernetes/structures_test.go
@@ -17,6 +17,11 @@ func TestIsInternalKey(t *testing.T) {
 		{"any.kubernetes.io", true},
 		{"kubernetes.io", true},
 		{"pv.kubernetes.io/any/path", true},
+		{"kubernetes.io/egress-bandwidth", false},
+		{"kubernetes.io/ingress.class", false},
+		{"app.kubernetes.io/any/path", false},
+		{"service.beta.kubernetes.io/any/path", false},
+		{"nginx.ingress.kubernetes.io/any/path", false},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {


### PR DESCRIPTION
Fixes #72 

This PR alters the internal key checking to stop it filtering out important annotations that contain `kubernetes.io`. The externalKeys slice contains all the internal labels I could find in my cluster that should be included. No doubt there are some that have been left out but this could be a good starting point.

An example of an annotation that is currently filtered out by this is the AWS internal loadbalancer annotation:

```
  service.beta.kubernetes.io/aws-load-balancer-internal: '0.0.0.0/0'
```