### PR TITLE
Add missing empty_dir size_limit 

### DIFF
--- a/kubernetes/resource_kubernetes_pod_test.go
+++ b/kubernetes/resource_kubernetes_pod_test.go
@@ -408,6 +408,7 @@ func TestAccKubernetesPod_with_empty_dir_volume(t *testing.T) {
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.0.mount_path", "/cache"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.container.0.volume_mount.0.name", "cache-volume"),
 					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.empty_dir.0.medium", "Memory"),
+					resource.TestCheckResourceAttr("kubernetes_pod.test", "spec.0.volume.0.empty_dir.0.size_limit", "1Gi"),
 				),
 			},
 		},
@@ -1044,6 +1045,7 @@ resource "kubernetes_pod" "test" {
     volume {
       name = "cache-volume"
       empty_dir = {
+        size_limit = "1Gi"
         medium = "Memory"
       }
     }

--- a/kubernetes/resource_kubernetes_replication_controller_test.go
+++ b/kubernetes/resource_kubernetes_replication_controller_test.go
@@ -381,6 +381,7 @@ func TestAccKubernetesReplicationController_with_empty_dir_volume(t *testing.T) 
 					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.volume_mount.0.mount_path", "/cache"),
 					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.container.0.volume_mount.0.name", "cache-volume"),
 					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.volume.0.empty_dir.0.medium", "Memory"),
+					resource.TestCheckResourceAttr("kubernetes_replication_controller.test", "spec.0.template.0.volume.0.empty_dir.0.size_limit", "1Gi"),
 				),
 			},
 		},
@@ -842,6 +843,7 @@ resource "kubernetes_replication_controller" "test" {
         name = "cache-volume"
         empty_dir = {
           medium = "Memory"
+          size_limit = "1Gi"
         }
       }
     }

--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -445,6 +445,12 @@ func volumeSchema() *schema.Resource {
 					Default:      "",
 					ValidateFunc: validateAttributeValueIsIn([]string{"", "Memory"}),
 				},
+				"size_limit": {
+					Type:        schema.TypeString,
+					Description: `Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir`,
+					Optional:    true,
+					Default:     "",
+				},
 			},
 		},
 	}

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -358,6 +358,7 @@ func flattenConfigMapVolumeSource(in *v1.ConfigMapVolumeSource) []interface{} {
 func flattenEmptyDirVolumeSource(in *v1.EmptyDirVolumeSource) []interface{} {
 	att := make(map[string]interface{})
 	att["medium"] = in.Medium
+	att["size_limit"] = in.SizeLimit
 	return []interface{}{att}
 }
 

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // Flatteners
@@ -358,7 +359,7 @@ func flattenConfigMapVolumeSource(in *v1.ConfigMapVolumeSource) []interface{} {
 func flattenEmptyDirVolumeSource(in *v1.EmptyDirVolumeSource) []interface{} {
 	att := make(map[string]interface{})
 	att["medium"] = in.Medium
-	att["size_limit"] = in.SizeLimit
+	att["size_limit"] = in.SizeLimit.String()
 	return []interface{}{att}
 }
 
@@ -724,15 +725,20 @@ func expandGitRepoVolumeSource(l []interface{}) *v1.GitRepoVolumeSource {
 	return obj
 }
 
-func expandEmptyDirVolumeSource(l []interface{}) *v1.EmptyDirVolumeSource {
+func expandEmptyDirVolumeSource(l []interface{}) (*v1.EmptyDirVolumeSource, error) {
 	if len(l) == 0 || l[0] == nil {
-		return &v1.EmptyDirVolumeSource{}
+		return &v1.EmptyDirVolumeSource{}, nil
 	}
 	in := l[0].(map[string]interface{})
-	obj := &v1.EmptyDirVolumeSource{
-		Medium: v1.StorageMedium(in["medium"].(string)),
+	v, err := resource.ParseQuantity(in["size_limit"].(string))
+	if err != nil {
+		return &v1.EmptyDirVolumeSource{}, err
 	}
-	return obj
+	obj := &v1.EmptyDirVolumeSource{
+		Medium:    v1.StorageMedium(in["medium"].(string)),
+		SizeLimit: &v,
+	}
+	return obj, nil
 }
 
 func expandPersistentVolumeClaimVolumeSource(l []interface{}) *v1.PersistentVolumeClaimVolumeSource {
@@ -785,7 +791,11 @@ func expandVolumes(volumes []interface{}) ([]v1.Volume, error) {
 		}
 
 		if value, ok := m["empty_dir"].([]interface{}); ok && len(value) > 0 {
-			vl[i].EmptyDir = expandEmptyDirVolumeSource(value)
+			var err error
+			vl[i].EmptyDir, err = expandEmptyDirVolumeSource(value)
+			if err != nil {
+				return vl, err
+			}
 		}
 		if value, ok := m["downward_api"].([]interface{}); ok && len(value) > 0 {
 			var err error


### PR DESCRIPTION
This PR adds `empty_dir.0.size_limit` for pod specs.

Minikube acceptance test outputs:
```
$ KUBE_CTX_AUTH_INFO=minikube KUBE_CTX_CLUSTER=minikube TESTARGS="-run TestAccKubernetesPod_with_empty_dir_volume" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccKubernetesPod_with_empty_dir_volume -timeout 120m
?   	github.com/sl1pm4t/terraform-provider-kubernetes	[no test files]
=== RUN   TestAccKubernetesPod_with_empty_dir_volume
--- PASS: TestAccKubernetesPod_with_empty_dir_volume (18.77s)
PASS
ok  	github.com/sl1pm4t/terraform-provider-kubernetes/kubernetes	18.819s
```

```
$ KUBE_CTX_AUTH_INFO=minikube KUBE_CTX_CLUSTER=minikube TESTARGS="-run TestAccKubernetesReplicationController_with_empty_dir_volume" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccKubernetesReplicationController_with_empty_dir_volume -timeout 120m
?   	github.com/sl1pm4t/terraform-provider-kubernetes	[no test files]
=== RUN   TestAccKubernetesReplicationController_with_empty_dir_volume
--- PASS: TestAccKubernetesReplicationController_with_empty_dir_volume (1.30s)
PASS
ok  	github.com/sl1pm4t/terraform-provider-kubernetes/kubernetes	1.352s
```