### PR TITLE
Fix: StatefulSet pod_management_policy

### DIFF
--- a/kubernetes/resource_kubernetes_stateful_set.go
+++ b/kubernetes/resource_kubernetes_stateful_set.go
@@ -60,16 +60,19 @@ func resourceKubernetesStatefulSet() *schema.Resource {
 							Description: "revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.",
 							Optional:    true,
 							Default:     10,
+							ForceNew:    true,
 						},
 						"selector": {
 							Type:        schema.TypeMap,
 							Description: "A label query over pods that should match the Replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
 							Required:    true,
+							ForceNew:    true,
 						},
 						"service_name": {
 							Type:        schema.TypeString,
 							Description: "The name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where \"pod-specific-string\" is managed by the StatefulSet controller.",
 							Required:    true,
+							ForceNew:    true,
 						},
 						"template": {
 							Type:        schema.TypeList,

--- a/kubernetes/resource_kubernetes_stateful_set.go
+++ b/kubernetes/resource_kubernetes_stateful_set.go
@@ -47,6 +47,7 @@ func resourceKubernetesStatefulSet() *schema.Resource {
 							Description: "Controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is OrderedReady, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is Parallel which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.",
 							Optional:    true,
 							Default:     "OrderedReady",
+							ForceNew:    true,
 						},
 						"replicas": {
 							Type:        schema.TypeInt,

--- a/kubernetes/structures_stateful_set.go
+++ b/kubernetes/structures_stateful_set.go
@@ -76,6 +76,10 @@ func expandStatefulSetSpec(statefulSet []interface{}) (appsv1.StatefulSetSpec, e
 	}
 	in := statefulSet[0].(map[string]interface{})
 
+	if v, ok := in["pod_management_policy"].(string); ok {
+		obj.PodManagementPolicy = appsv1.PodManagementPolicyType(v)
+	}
+
 	if v, ok := in["update_strategy"]; ok {
 		obj.UpdateStrategy = expandStatefulSetUpdateStrategy(v.([]interface{}))
 	}


### PR DESCRIPTION
The provider would silently fail to set the configured `pod_management_policy`. 
This is now fixed.