### PR TITLE
Fix TF re-adding annotations on every apply

### DIFF
--- a/kubernetes/resource_kubernetes_deployment_test.go
+++ b/kubernetes/resource_kubernetes_deployment_test.go
@@ -496,6 +496,7 @@ resource "kubernetes_deployment" "test" {
 				"prometheus.io/scrape" = "true"
 				"prometheus.io/scheme" = "https"
 				"prometheus.io/port"   = "4000"
+                "kubernetes.io/egress-bandwidth" = "1M"
 			}
 		}
 		spec {

--- a/kubernetes/structures.go
+++ b/kubernetes/structures.go
@@ -97,9 +97,13 @@ func expandStringSlice(s []interface{}) []string {
 	return result
 }
 
-func flattenMetadata(meta metav1.ObjectMeta, d *schema.ResourceData) []map[string]interface{} {
+func flattenMetadata(meta metav1.ObjectMeta, d *schema.ResourceData, metaPrefix ...string) []map[string]interface{} {
 	m := make(map[string]interface{})
-	configAnnotations := d.Get("metadata.0.annotations").(map[string]interface{})
+	prefix := ""
+	if len(metaPrefix) > 0 {
+		prefix = metaPrefix[0]
+	}
+	configAnnotations := d.Get(prefix + "metadata.0.annotations").(map[string]interface{})
 	m["annotations"] = removeInternalKeys(meta.Annotations, configAnnotations)
 	if meta.GenerateName != "" {
 		m["generate_name"] = meta.GenerateName

--- a/kubernetes/structures_daemonset.go
+++ b/kubernetes/structures_daemonset.go
@@ -22,7 +22,7 @@ func flattenDaemonSetSpec(in appsv1.DaemonSetSpec, d *schema.ResourceData) ([]in
 	// }
 	// att["template"] = podSpec
 
-	templateMetadata := flattenMetadata(in.Template.ObjectMeta, d)
+	templateMetadata := flattenMetadata(in.Template.ObjectMeta, d, "spec.0.template.0.")
 	podSpec, err := flattenPodSpec(in.Template.Spec)
 	if err != nil {
 		return nil, err

--- a/kubernetes/structures_deployment.go
+++ b/kubernetes/structures_deployment.go
@@ -35,7 +35,7 @@ func flattenDeploymentSpec(in appsv1.DeploymentSpec, d *schema.ResourceData) ([]
 	att["selector"] = in.Selector.MatchLabels
 	att["strategy"] = flattenDeploymentStrategy(in.Strategy)
 
-	templateMetadata := flattenMetadata(in.Template.ObjectMeta, d)
+	templateMetadata := flattenMetadata(in.Template.ObjectMeta, d, "spec.0.template.0.")
 	podSpec, err := flattenPodSpec(in.Template.Spec)
 	if err != nil {
 		return nil, err

--- a/kubernetes/structures_stateful_set.go
+++ b/kubernetes/structures_stateful_set.go
@@ -23,7 +23,7 @@ func flattenStatefulSetSpec(in appsv1.StatefulSetSpec, d *schema.ResourceData) (
 	att["selector"] = in.Selector.MatchLabels
 	att["update_strategy"] = flattenStatefulSetUpdateStrategy(in.UpdateStrategy, d)
 
-	templateMetadata := flattenMetadata(in.Template.ObjectMeta, d)
+	templateMetadata := flattenMetadata(in.Template.ObjectMeta, d, "spec.0.template.0.")
 	podSpec, err := flattenPodSpec(in.Template.Spec)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #72 

This fixes an issue that could cause Terraform to attempt to re-apply certain annotations on every run.
This fix already applied to top level annotations, but needed to be added to annotations within a PodTemplate (i.e nested inside a Deployment, DaemonSet, StatefulSet spec)

Before the fix, the modified Deployment test case fails with:
```
--- FAIL: TestAccKubernetesDeployment_with_template_metadata (69.35s)
    testing.go:518: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: kubernetes_deployment.test
          spec.0.template.0.metadata.0.annotations.%:                              "3" => "4"
          spec.0.template.0.metadata.0.annotations.kubernetes.io/egress-bandwidth: "" => "1M"
```

After the change:

```
--- PASS: TestAccKubernetesDeployment_with_template_metadata (135.66s)
PASS
```