### PR TITLE
EmptyDir ‘size_limit’ causing quantity parse error

### DIFF
--- a/kubernetes/schema_pod_spec.go
+++ b/kubernetes/schema_pod_spec.go
@@ -253,7 +253,7 @@ func podSpecFields(isUpdatable bool) map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Optional:    true,
 			Description: "List of volumes that can be mounted by containers belonging to the pod. More info: http://kubernetes.io/docs/user-guide/volumes",
-			Elem:        volumeSchema(),
+			Elem:        volumeSchema(isUpdatable),
 		},
 	}
 
@@ -274,7 +274,7 @@ func podSpecFields(isUpdatable bool) map[string]*schema.Schema {
 	return s
 }
 
-func volumeSchema() *schema.Resource {
+func volumeSchema(isUpdatable bool) *schema.Resource {
 	v := commonVolumeSources()
 
 	v["config_map"] = &schema.Schema{
@@ -446,10 +446,12 @@ func volumeSchema() *schema.Resource {
 					ValidateFunc: validateAttributeValueIsIn([]string{"", "Memory"}),
 				},
 				"size_limit": {
-					Type:        schema.TypeString,
-					Description: `Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir`,
-					Optional:    true,
-					Default:     "",
+					Type:         schema.TypeString,
+					Description:  `Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir`,
+					Optional:     true,
+					Default:      "0",
+					ForceNew:     !isUpdatable,
+					ValidateFunc: validateResourceQuantity,
 				},
 			},
 		},

--- a/kubernetes/structures_pod.go
+++ b/kubernetes/structures_pod.go
@@ -734,13 +734,19 @@ func expandEmptyDirVolumeSource(l []interface{}) (*v1.EmptyDirVolumeSource, erro
 		return &v1.EmptyDirVolumeSource{}, nil
 	}
 	in := l[0].(map[string]interface{})
-	v, err := resource.ParseQuantity(in["size_limit"].(string))
-	if err != nil {
-		return &v1.EmptyDirVolumeSource{}, err
+
+	var quantity resource.Quantity
+	if cfg, ok := in["size_limit"].(string); ok && len(cfg) > 0 {
+		var err error
+		quantity, err = resource.ParseQuantity(cfg)
+		if err != nil {
+			return &v1.EmptyDirVolumeSource{}, err
+		}
 	}
+
 	obj := &v1.EmptyDirVolumeSource{
 		Medium:    v1.StorageMedium(in["medium"].(string)),
-		SizeLimit: &v,
+		SizeLimit: &quantity,
 	}
 	return obj, nil
 }


### PR DESCRIPTION
If `size_limit` was not set, a confusing error would be reported that the quantity did not match pattern.

On a Pod, this PR will also force destroy + re-create of a Pod if the `size_limit` is changed. For Deployments and other higher level resources changing the size_limit will trigger a rolling update.